### PR TITLE
Support nested MorphTo filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Email automated exports on a defined schedule - keep the management happy with t
 
 ## Filter By Available Relationships
 - BelongsTo relations (with 'InteractsWithExportScheduler' trait set on the relation class) are automatically discovered.
+- MorphTo relations can be filtered using dot notation paths.
 - Exclude relations with the 'excludeFilterableRelations' method available in the 'InteractsWithExportScheduler' trait.
 
 ![Filter by relations](https://raw.githubusercontent.com/visualbuilder/filament-export-scheduler/3x-with-relationships/media/filter-by-relations.png)
@@ -237,8 +238,8 @@ Typical scenario might be exporting all Orders but filtered by a specific Organi
 This requires adding the ``InteractsWithExportSchedulerFilter`` to the Models that can be filtered.
 
 The trait has the $filterOptionLabel property allowing us to define which column should be used for the filter label.
-And excludeFilterableRelations allows you to exclude relations which should not be included in the filter, by default all belongsTo relations will be included.
-NB. Next release will include morphsTo relation options.
+And excludeFilterableRelations allows you to exclude relations which should not be included in the filter, by default all BelongsTo relations will be included.
+MorphTo relations are also supported when filtering nested attributes.
 
 }
 

--- a/src/Services/ScheduledExporter.php
+++ b/src/Services/ScheduledExporter.php
@@ -96,15 +96,47 @@ class ScheduledExporter
                             $column = array_pop($parts);
                             $relationPath = implode('.', $parts);
 
-                            $query->{$condition === 'or' ? 'orWhereHas' : 'whereHas'}($relationPath, function ($subQuery) use ($column, $operator, $value) {
-                                if (in_array($operator, ['in', 'not_in']) && is_array($value)) {
-                                    $subQuery->{$operator === 'in' ? 'whereIn' : 'whereNotIn'}($column, $value);
-                                } else if ($operator === 'like') {
-                                    $subQuery->where($column, 'LIKE', "%$value%");
-                                } else {
-                                    $subQuery->where($column, $operator, $value);
-                                }
-                            });
+                            $firstRelation = $parts[0];
+                            $modelClass = $this->exportSchedule->exporter::getModel();
+                            $relationMethod = method_exists($modelClass, $firstRelation)
+                                ? (new $modelClass)->$firstRelation()
+                                : null;
+
+                            if ($relationMethod instanceof \Illuminate\Database\Eloquent\Relations\MorphTo) {
+                                $remainingPath = implode('.', array_slice($parts, 1));
+                                $types = $this->getMorphTypes();
+                                $query->{$condition === 'or' ? 'orWhereHasMorph' : 'whereHasMorph'}($firstRelation, $types, function ($morphQuery) use ($remainingPath, $column, $operator, $value) {
+                                    if ($remainingPath) {
+                                        $morphQuery->whereHas($remainingPath, function ($subQuery) use ($column, $operator, $value) {
+                                            if (in_array($operator, ['in', 'not_in']) && is_array($value)) {
+                                                $subQuery->{$operator === 'in' ? 'whereIn' : 'whereNotIn'}($column, $value);
+                                            } elseif ($operator === 'like') {
+                                                $subQuery->where($column, 'LIKE', "%$value%");
+                                            } else {
+                                                $subQuery->where($column, $operator, $value);
+                                            }
+                                        });
+                                    } else {
+                                        if (in_array($operator, ['in', 'not_in']) && is_array($value)) {
+                                            $morphQuery->{$operator === 'in' ? 'whereIn' : 'whereNotIn'}($column, $value);
+                                        } elseif ($operator === 'like') {
+                                            $morphQuery->where($column, 'LIKE', "%$value%");
+                                        } else {
+                                            $morphQuery->where($column, $operator, $value);
+                                        }
+                                    }
+                                });
+                            } else {
+                                $query->{$condition === 'or' ? 'orWhereHas' : 'whereHas'}($relationPath, function ($subQuery) use ($column, $operator, $value) {
+                                    if (in_array($operator, ['in', 'not_in']) && is_array($value)) {
+                                        $subQuery->{$operator === 'in' ? 'whereIn' : 'whereNotIn'}($column, $value);
+                                    } elseif ($operator === 'like') {
+                                        $subQuery->where($column, 'LIKE', "%$value%");
+                                    } else {
+                                        $subQuery->where($column, $operator, $value);
+                                    }
+                                });
+                            }
                         } else {
                             if ($operator === '<>' && filled($dateRange = DateRange::tryFrom($value))) {
                                 ['start' => $startDate, 'end' => $endDate] = $dateRange->getDateRange();
@@ -155,6 +187,22 @@ class ScheduledExporter
     protected function generateFileName(): string
     {
         return Str::slug($this->exportSchedule->name . '_' . now()->format('Y-m-d_Hi'));
+    }
+
+    protected function getMorphTypes(): array
+    {
+        $types = collect(config('export-scheduler.user_models', []))
+            ->map(function ($model) {
+                return is_array($model) ? ($model['model'] ?? null) : $model;
+            })
+            ->filter()
+            ->values();
+
+        if ($this->exportSchedule->owner_type) {
+            $types->push($this->exportSchedule->owner_type);
+        }
+
+        return $types->unique()->all();
     }
 
     public function buildJobChain(): bool

--- a/tests/Exporters/DocumentExporter.php
+++ b/tests/Exporters/DocumentExporter.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace VisualBuilder\ExportScheduler\Tests\Exporters;
+
+use Filament\Actions\Exports\ExportColumn;
+use Filament\Actions\Exports\Exporter;
+use VisualBuilder\ExportScheduler\Tests\Models\Document;
+
+class DocumentExporter extends Exporter
+{
+    protected static ?string $model = Document::class;
+
+    public static function getColumns(): array
+    {
+        return [
+            ExportColumn::make('id'),
+            ExportColumn::make('title'),
+        ];
+    }
+}

--- a/tests/Feature/MorphToFilterTest.php
+++ b/tests/Feature/MorphToFilterTest.php
@@ -1,0 +1,42 @@
+<?php
+
+use VisualBuilder\ExportScheduler\Enums\ScheduleFrequency;
+use VisualBuilder\ExportScheduler\Models\ExportSchedule;
+use VisualBuilder\ExportScheduler\Services\ScheduledExporter;
+use VisualBuilder\ExportScheduler\Tests\Exporters\DocumentExporter;
+use VisualBuilder\ExportScheduler\Tests\Models\Contact;
+use VisualBuilder\ExportScheduler\Tests\Models\Document;
+use VisualBuilder\ExportScheduler\Tests\Models\Organisation;
+
+it('applies attribute filter on nested MorphTo relation', function () {
+    $contact = Contact::create(['full_name' => 'John Doe']);
+    $org = Organisation::create(['name' => 'Acme', 'primary_contact_id' => $contact->id]);
+    Document::create(['title' => 'Doc', 'owner_type' => Organisation::class, 'owner_id' => $org->id]);
+
+    $schedule = ExportSchedule::create([
+        'name' => 'Document Export',
+        'exporter' => DocumentExporter::class,
+        'schedule_frequency' => ScheduleFrequency::DAILY,
+        'schedule_time' => now()->toTimeString(),
+        'next_run_at' => now(),
+        'columns' => [
+            ['name' => 'id', 'label' => 'ID'],
+            ['name' => 'title', 'label' => 'Title'],
+        ],
+        'owner_id' => auth()->id(),
+        'owner_type' => get_class(auth()->user()),
+        'filters' => [
+            'attributes' => [
+                [
+                    'column' => 'owner.primary_contact.full_name',
+                    'value' => 'John',
+                    'operator' => 'like',
+                    'condition' => 'and',
+                ],
+            ],
+        ],
+    ]);
+
+    $exporter = new ScheduledExporter($schedule);
+    expect($exporter->run())->toBeTrue();
+});

--- a/tests/Models/Contact.php
+++ b/tests/Models/Contact.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace VisualBuilder\ExportScheduler\Tests\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Contact extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['full_name'];
+
+    protected $table = 'contacts';
+}

--- a/tests/Models/Document.php
+++ b/tests/Models/Document.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace VisualBuilder\ExportScheduler\Tests\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+class Document extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['title', 'owner_type', 'owner_id'];
+
+    protected $table = 'documents';
+
+    public function owner(): MorphTo
+    {
+        return $this->morphTo();
+    }
+}

--- a/tests/Models/Organisation.php
+++ b/tests/Models/Organisation.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace VisualBuilder\ExportScheduler\Tests\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Organisation extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['name', 'primary_contact_id'];
+
+    protected $table = 'organisations';
+
+    public function primary_contact(): BelongsTo
+    {
+        return $this->belongsTo(Contact::class, 'primary_contact_id');
+    }
+}

--- a/tests/database/schema/test-schema.sql
+++ b/tests/database/schema/test-schema.sql
@@ -87,6 +87,48 @@ PRIMARY KEY (`id`),
 UNIQUE KEY `users_email_unique` (`email`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
+
+DROP TABLE IF EXISTS `contacts`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `contacts` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `full_name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `created_at` timestamp NULL DEFAULT NULL,
+  `updated_at` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+DROP TABLE IF EXISTS `organisations`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `organisations` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `primary_contact_id` bigint unsigned DEFAULT NULL,
+  `created_at` timestamp NULL DEFAULT NULL,
+  `updated_at` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `organisations_primary_contact_id_foreign` (`primary_contact_id`),
+  CONSTRAINT `organisations_primary_contact_id_foreign` FOREIGN KEY (`primary_contact_id`) REFERENCES `contacts` (`id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+DROP TABLE IF EXISTS `documents`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `documents` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `title` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `owner_type` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `owner_id` bigint unsigned DEFAULT NULL,
+  `created_at` timestamp NULL DEFAULT NULL,
+  `updated_at` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `documents_owner_type_owner_id_index` (`owner_type`,`owner_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `imports`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;


### PR DESCRIPTION
## Summary
- handle MorphTo relations using `whereHasMorph`
- document MorphTo filter support
- add regression test
- add sample models/tables for MorphTo tests

## Testing
- `composer test` *(fails: composer not found)*
- `./vendor/bin/pest` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685c8e4d9cf8833387933827e0ace4a0