### PR TITLE
Add Codex environment setup

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -euo pipefail
+
+# Update package lists
+apt-get update
+
+# Install PHP and common extensions
+apt-get install -y php php-cli php-fpm php-common php-mbstring php-xml php-gd php-curl php-mysql php-zip php-bcmath
+
+# Install MySQL server
+apt-get install -y mysql-server
+
+# Install Composer (dependency manager for PHP)
+EXPECTED_CHECKSUM="$(wget -q -O - https://composer.github.io/installer.sig)"
+php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+ACTUAL_CHECKSUM="$(php -r "echo hash_file('sha384', 'composer-setup.php');")"
+if [ "$EXPECTED_CHECKSUM" != "$ACTUAL_CHECKSUM" ]; then
+    >&2 echo 'ERROR: Invalid Composer installer checksum'
+    rm composer-setup.php
+    exit 1
+fi
+php composer-setup.php --install-dir=/usr/local/bin --filename=composer
+rm composer-setup.php
+
+# Clean up apt caches
+apt-get clean
+rm -rf /var/lib/apt/lists/*
+

--- a/README.md
+++ b/README.md
@@ -286,6 +286,11 @@ To prove the integrity of the system the test suite creates these schedules and 
 | User Export Weekdays 10:30 AM   | CRON               | `30 10 * * 1-5`          | Every weekday (Monday-Friday) at 10:30 AM                        | Check for a new file/email at 10:30 AM each weekday.           |
 | User Export Quarter Ends 2:00 AM | CRON               | `0 2 1 3,6,9,12 *`      | The 1st day of March, June, September, and December at 2:00 AM    | Check for a new file/email on these dates at 2:00 AM.            |
 
+
+## Codex Setup
+
+When using this repository in the OpenAI Codex environment, a `.codex/setup.sh` script will install PHP, MySQL, and Composer during initialization when network access is available.
+
 ## Changelog
 
 Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed recently.


### PR DESCRIPTION
## Summary
- add `.codex/setup.sh` to install PHP, MySQL and Composer when the Codex container initializes
- document Codex setup script in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685c9595fd98833386efe0a8607a265c