### PR TITLE
Support "since" relative date filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,10 @@ Email automated exports on a defined schedule - keep the management happy with t
   - this month
   - last quarter
   - this year
-  - last year
+- last year
 - Custom date field if not created_at can be set in the Exporter
+
+You can also specify a custom period using **since X days/weeks/months/years ago** for even more flexibility.
 
 ## Users can choose which columns to include
 

--- a/resources/lang/en/scheduler.php
+++ b/resources/lang/en/scheduler.php
@@ -24,6 +24,7 @@ return [
     'cron_expression_hint'       => "A Cron expression defines a schedule for tasks to run automatically.<br>It uses a format like * * * * * representing minutes, hours, days, months, and weekdays.</p><p>For example:<br>&nbsp;&nbsp;&nbsp;0 9 * * * runs every day at 9:00 AM.<br>&nbsp;&nbsp;&nbsp;0 0 1 * * runs on the 1st of every month at midnight.<br>You can use an online tool to generate Cron expressions<br><a class='underline' href='https://crontab.guru'>https://crontab.guru</a>",
 
     'date_range'             => 'Date Range',
+    'since'                  => 'Since',
     'date_range_tooltip'     => 'Leave blank for all records.  Attribute will be created_at unless changed in the Exporter',
     'date_range_placeholder' => 'Select a relative date range query. Blank for all records',
     'owner'                  => 'Report Owner',
@@ -68,6 +69,12 @@ return [
     'october'                => 'October',
     'november'               => 'November',
     'december'               => 'December',
+
+    // Relative date units
+    'days'                   => 'Days',
+    'weeks'                  => 'Weeks',
+    'months'                 => 'Months',
+    'years'                  => 'Years',
 
     //FileTypes
     'CSV'                    => 'CSV',

--- a/src/Filament/Forms/Fields.php
+++ b/src/Filament/Forms/Fields.php
@@ -263,7 +263,7 @@ class Fields
                                                 ],
 
                                                 // date/datetime/timestamp
-                                                Helper::isDateTimeCast($column, $type) => ['<>' => 'is from'],
+                                                Helper::isDateTimeCast($column, $type) => ['<>' => 'is from', 'since' => 'since'],
 
                                                 // boolean
                                                 Helper::isBooleanCast($type) => [
@@ -292,6 +292,7 @@ class Fields
                                             $key = 'value';
                                             $enumCast = Helper::extractEnumCast($column, $exporterModel);
 
+                                            $operator = $get('operator');
                                             $field = match (true) {
                                                 // enum
                                                 filled($enumCast) => Select::make($key)
@@ -303,7 +304,9 @@ class Fields
                                                     ),
 
                                                 // date/datetime/timestamp
-                                                Helper::isDateTimeCast($column, $type) => self::dateRange($key),
+                                                Helper::isDateTimeCast($column, $type) => $operator === 'since'
+                                                    ? self::dateSince($key)
+                                                    : self::dateRange($key),
 
                                                 // boolean
                                                 Helper::isBooleanCast($type) => Toggle::make($key),
@@ -312,7 +315,11 @@ class Fields
                                                 default => TextInput::make($key)
                                             };
 
-                                            return [$field->required()];
+                                            if (method_exists($field, 'required')) {
+                                                $field = $field->required();
+                                            }
+
+                                            return [$field];
                                         })
                                 ])
                         ])
@@ -523,6 +530,27 @@ class Fields
             ->label(__('export-scheduler::scheduler.date_range'))
             ->options(DateRange::selectArray())
             ->native(false);
+    }
+
+    public static function dateSince($key = 'since'): Group
+    {
+        return Group::make()
+            ->columns(2)
+            ->schema([
+                TextInput::make("{$key}.amount")
+                    ->numeric()
+                    ->default(1)
+                    ->required(),
+                Select::make("{$key}.unit")
+                    ->options([
+                        'days' => __('export-scheduler::scheduler.days'),
+                        'weeks' => __('export-scheduler::scheduler.weeks'),
+                        'months' => __('export-scheduler::scheduler.months'),
+                        'years' => __('export-scheduler::scheduler.years'),
+                    ])
+                    ->native(false)
+                    ->required(),
+            ]);
     }
 
     public static function formats(): Select

--- a/src/Services/ScheduledExporter.php
+++ b/src/Services/ScheduledExporter.php
@@ -7,6 +7,7 @@ use Filament\Actions\Exports\Enums\ExportFormat;
 use Filament\Actions\Exports\Exporter;
 use Filament\Actions\Exports\Jobs\CreateXlsxFile;
 use Filament\Actions\Exports\Models\Export;
+use Carbon\Carbon;
 use Illuminate\Bus\PendingBatch;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Foundation\Bus\PendingChain;
@@ -108,7 +109,18 @@ class ScheduledExporter
                                 $query->{$condition === 'or' ? 'orWhereHasMorph' : 'whereHasMorph'}($firstRelation, $types, function ($morphQuery) use ($remainingPath, $column, $operator, $value) {
                                     if ($remainingPath) {
                                         $morphQuery->whereHas($remainingPath, function ($subQuery) use ($column, $operator, $value) {
-                                            if (in_array($operator, ['in', 'not_in']) && is_array($value)) {
+                                            if ($operator === 'since' && is_array($value)) {
+                                                $date = Carbon::now();
+                                                $amount = (int) ($value['amount'] ?? 0);
+                                                $unit = $value['unit'] ?? 'days';
+                                                match ($unit) {
+                                                    'weeks' => $date->subWeeks($amount),
+                                                    'months' => $date->subMonths($amount),
+                                                    'years' => $date->subYears($amount),
+                                                    default => $date->subDays($amount),
+                                                };
+                                                $subQuery->where($column, '>=', $date);
+                                            } elseif (in_array($operator, ['in', 'not_in']) && is_array($value)) {
                                                 $subQuery->{$operator === 'in' ? 'whereIn' : 'whereNotIn'}($column, $value);
                                             } elseif ($operator === 'like') {
                                                 $subQuery->where($column, 'LIKE', "%$value%");
@@ -117,7 +129,18 @@ class ScheduledExporter
                                             }
                                         });
                                     } else {
-                                        if (in_array($operator, ['in', 'not_in']) && is_array($value)) {
+                                    if ($operator === 'since' && is_array($value)) {
+                                            $date = Carbon::now();
+                                            $amount = (int) ($value['amount'] ?? 0);
+                                            $unit = $value['unit'] ?? 'days';
+                                            match ($unit) {
+                                                'weeks' => $date->subWeeks($amount),
+                                                'months' => $date->subMonths($amount),
+                                                'years' => $date->subYears($amount),
+                                                default => $date->subDays($amount),
+                                            };
+                                            $morphQuery->where($column, '>=', $date);
+                                        } elseif (in_array($operator, ['in', 'not_in']) && is_array($value)) {
                                             $morphQuery->{$operator === 'in' ? 'whereIn' : 'whereNotIn'}($column, $value);
                                         } elseif ($operator === 'like') {
                                             $morphQuery->where($column, 'LIKE', "%$value%");
@@ -141,7 +164,18 @@ class ScheduledExporter
                             if ($operator === '<>' && filled($dateRange = DateRange::tryFrom($value))) {
                                 ['start' => $startDate, 'end' => $endDate] = $dateRange->getDateRange();
                                 $query->{$condition === 'or' ? 'orWhereBetween' : 'whereBetween'}($column, [$startDate, $endDate]);
-                            } else if (in_array($operator, ['in', 'not_in']) && is_array($value)) {
+                            } elseif ($operator === 'since' && is_array($value)) {
+                                $date = Carbon::now();
+                                $amount = (int) ($value['amount'] ?? 0);
+                                $unit = $value['unit'] ?? 'days';
+                                match ($unit) {
+                                    'weeks' => $date->subWeeks($amount),
+                                    'months' => $date->subMonths($amount),
+                                    'years' => $date->subYears($amount),
+                                    default => $date->subDays($amount),
+                                };
+                                $query->{$condition === 'or' ? 'orWhere' : 'where'}($column, '>=', $date);
+                            } elseif (in_array($operator, ['in', 'not_in']) && is_array($value)) {
                                 $query->{$condition === 'or' ? 'orWhereIn' : 'whereIn'}($column, $value);
                             } elseif ($operator === 'like') {
                                 $query->{$condition === 'or' ? 'orWhere' : 'where'}($column, 'LIKE', "%$value%");


### PR DESCRIPTION
## Summary
- support new `since` operator for date attributes
- render numeric/time unit input when using `since`
- handle `since` operator in `ScheduledExporter`
- add translations for date units
- document flexible date filter in README

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ca04a77508333be62a46a491b04b4