### PR TITLE
Set attribute filter defaults based on operator

### DIFF
--- a/src/Filament/Forms/Fields.php
+++ b/src/Filament/Forms/Fields.php
@@ -277,6 +277,13 @@ class Fields
                                                     'like' => 'is like',
                                                 ]
                                             };
+                                        })
+                                        ->afterStateUpdated(function ($state, Set $set) {
+                                            if ($state === 'since') {
+                                                $set('value', ['amount' => 1, 'unit' => 'days']);
+                                            } else {
+                                                $set('value', null);
+                                            }
                                         }),
 
                                     // value


### PR DESCRIPTION
## Summary
- update operator field so changing it resets the `value`
- if operator is `since` automatically provide a default date range value

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cbcc014688333a9d9a850b1a162c1