### PR TITLE
Add default value for since filter units

### DIFF
--- a/src/Filament/Forms/Fields.php
+++ b/src/Filament/Forms/Fields.php
@@ -549,6 +549,7 @@ class Fields
                         'months' => __('export-scheduler::scheduler.months'),
                         'years' => __('export-scheduler::scheduler.years'),
                     ])
+                    ->default('days')
                     ->native(false)
                     ->required(),
             ]);


### PR DESCRIPTION
## Summary
- ensure `dateSince()` select field has a default unit of `days`

## Testing
- `composer install --no-interaction --no-progress --prefer-dist` *(fails: composer not found)*
- `./vendor/bin/pest` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685cbd3cc08883339410cbf80fbeb263