### PR TITLE
Fix datetime detection for nested export columns

### DIFF
--- a/src/Filament/Forms/Fields.php
+++ b/src/Filament/Forms/Fields.php
@@ -258,8 +258,7 @@ class Fields
                                         ->options(function (Get $get) use ($columns, $exporterClass) {
                                             $column = $get('column');
                                             $exporterModel = (new \ReflectionClass($exporterClass))->getStaticPropertyValue('model');
-                                            $casts = (new $exporterModel)->getCasts();
-                                            $type = $casts[$column] ?? null;
+                                            $type = Helper::extractCastType($column, $exporterModel);
 
                                             return match (true) {
                                                 // enum
@@ -293,8 +292,7 @@ class Fields
 
                                             $column = $get('column');
                                             $exporterModel = (new \ReflectionClass($exporterClass))->getStaticPropertyValue('model');
-                                            $casts = (new $exporterModel)->getCasts();
-                                            $type = $casts[$column] ?? null;
+                                            $type = Helper::extractCastType($column, $exporterModel);
                                             $key = 'value';
                                             $enumCast = Helper::extractEnumCast($column, $exporterModel);
 

--- a/src/Filament/Forms/Helper.php
+++ b/src/Filament/Forms/Helper.php
@@ -40,8 +40,38 @@ class Helper
 
     public static function isDateTimeCast($column, $type): bool
     {
-        return in_array($column, ['created_at', 'updated_at', 'deleted_at'])
-            || in_array($type, ['date', 'datetime', 'timestamp']);
+        $segments = explode('.', $column);
+        $lastSegment = array_pop($segments);
+
+        return str_ends_with($lastSegment, '_at')
+            || in_array($type, ['date', 'datetime', 'timestamp', 'immutable_date', 'immutable_datetime'])
+            || str_starts_with($type, 'date:')
+            || str_starts_with($type, 'datetime:')
+            || str_starts_with($type, 'timestamp:');
+    }
+
+    public static function extractCastType($path, $baseClass): ?string
+    {
+        $model = new $baseClass;
+        $segments = explode('.', $path);
+        $lastKey = array_pop($segments);
+
+        foreach ($segments as $segment) {
+            if (! method_exists($model, $segment)) {
+                return null; // invalid relation
+            }
+
+            $relation = $model->$segment();
+            if (! $relation instanceof Relation) {
+                return null; // not a valid eloquent relation
+            }
+
+            $model = $relation->getRelated();
+        }
+
+        $casts = $model->getCasts();
+
+        return $casts[$lastKey] ?? null;
     }
 
     public static function extractEnumCast($path, $baseClass): ?string

--- a/tests/Exporters/DocumentOwnerExporter.php
+++ b/tests/Exporters/DocumentOwnerExporter.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace VisualBuilder\ExportScheduler\Tests\Exporters;
+
+use Filament\Actions\Exports\ExportColumn;
+use Filament\Actions\Exports\Exporter;
+use Filament\Actions\Exports\Models\Export;
+use VisualBuilder\ExportScheduler\Tests\Models\Document;
+
+class DocumentOwnerExporter extends Exporter
+{
+    protected static ?string $model = Document::class;
+
+    public static function getColumns(): array
+    {
+        return [
+            ExportColumn::make('id'),
+            ExportColumn::make('title'),
+            ExportColumn::make('owner.created_at')->label('Owner Created At'),
+        ];
+    }
+
+    public static function getCompletedNotificationBody(Export $export): string
+    {
+        return 'Export completed';
+    }
+}

--- a/tests/Feature/NestedDateTimeFilterTest.php
+++ b/tests/Feature/NestedDateTimeFilterTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use VisualBuilder\ExportScheduler\Enums\ScheduleFrequency;
+use VisualBuilder\ExportScheduler\Models\ExportSchedule;
+use VisualBuilder\ExportScheduler\Services\ScheduledExporter;
+use VisualBuilder\ExportScheduler\Tests\Exporters\DocumentOwnerExporter;
+use VisualBuilder\ExportScheduler\Tests\Models\Contact;
+use VisualBuilder\ExportScheduler\Tests\Models\Document;
+use VisualBuilder\ExportScheduler\Tests\Models\Organisation;
+
+it('detects chained datetime attributes', function () {
+    $contact = Contact::create(['full_name' => 'John Doe']);
+    $org = Organisation::create(['name' => 'Acme', 'primary_contact_id' => $contact->id]);
+    Document::create(['title' => 'Doc', 'owner_type' => Organisation::class, 'owner_id' => $org->id]);
+
+    $schedule = ExportSchedule::create([
+        'name' => 'Document Export',
+        'exporter' => DocumentOwnerExporter::class,
+        'schedule_frequency' => ScheduleFrequency::DAILY,
+        'schedule_time' => now()->toTimeString(),
+        'next_run_at' => now(),
+        'columns' => [
+            ['name' => 'id', 'label' => 'ID'],
+            ['name' => 'title', 'label' => 'Title'],
+            ['name' => 'owner.created_at', 'label' => 'Owner Created At'],
+        ],
+        'owner_id' => auth()->id(),
+        'owner_type' => get_class(auth()->user()),
+        'filters' => [
+            'attributes' => [
+                [
+                    'column' => 'owner.created_at',
+                    'operator' => 'since',
+                    'value' => now()->subDay()->toDateString(),
+                    'condition' => 'and',
+                ],
+            ],
+        ],
+        'formats' => ["xlsx"]
+    ]);
+
+    $exporter = new ScheduledExporter($schedule);
+    expect($exporter->run())->toBeTrue();
+});


### PR DESCRIPTION
## Summary
- support chained datetime attributes in Helper
- look up cast type for nested attributes in `filterByAttributeSection`
- add regression test for chained datetime filter
- detect datetime by `_at` suffix and additional cast patterns

## Testing
- `composer test` *(fails: `vendor/bin/pest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6874f40f88408333be242fc07c1fdc57