### PR TITLE
fix: rename namespace to Visualbuilder

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-github: VisualBuilder
+github: Visualbuilder

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,11 @@
 blank_issues_enabled: false
 contact_links:
   - name: Ask a question
-    url: https://github.com/VisualBuilder/filament-export-scheduler/discussions/new?category=q-a
+    url: https://github.com/Visualbuilder/filament-export-scheduler/discussions/new?category=q-a
     about: Ask the community for help
   - name: Request a feature
-    url: https://github.com/VisualBuilder/filament-export-scheduler/discussions/new?category=ideas
+    url: https://github.com/Visualbuilder/filament-export-scheduler/discussions/new?category=ideas
     about: Share ideas for new features
   - name: Report a security issue
-    url: https://github.com/VisualBuilder/filament-export-scheduler/security/policy
+    url: https://github.com/Visualbuilder/filament-export-scheduler/security/policy
     about: Learn how to notify us for sensitive bugs

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Export::polymorphicUserRelationship();
 
 Add the plugin to your filament panel provider
 ```php
-use VisualBuilder\ExportScheduler\ExportSchedulerPlugin;
+use Visualbuilder\ExportScheduler\ExportSchedulerPlugin;
 
 public function panel(Panel $panel): Panel
     {

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "visualbuilder/filament-export-scheduler",
     "description": "Configure scheduled routines for filament exporters",
     "keywords": [
-        "VisualBuilder",
+        "Visualbuilder",
         "laravel",
         "filament-export-scheduler"
     ],
@@ -39,14 +39,14 @@
     },
     "autoload": {
         "psr-4": {
-            "VisualBuilder\\ExportScheduler\\": "src/",
-            "VisualBuilder\\ExportScheduler\\Database\\Factories\\": "database/factories/",
-            "VisualBuilder\\ExportScheduler\\Database\\Seeders\\": "database/seeders/"
+            "Visualbuilder\\ExportScheduler\\": "src/",
+            "Visualbuilder\\ExportScheduler\\Database\\Factories\\": "database/factories/",
+            "Visualbuilder\\ExportScheduler\\Database\\Seeders\\": "database/seeders/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "VisualBuilder\\ExportScheduler\\Tests\\": "tests/"
+            "Visualbuilder\\ExportScheduler\\Tests\\": "tests/"
         }
     },
     "scripts": {
@@ -66,10 +66,10 @@
     "extra": {
         "laravel": {
             "providers": [
-                "VisualBuilder\\ExportScheduler\\ExportSchedulerServiceProvider"
+                "Visualbuilder\\ExportScheduler\\ExportSchedulerServiceProvider"
             ],
             "aliases": {
-                "ExportScheduler": "VisualBuilder\\ExportScheduler\\Facades\\ExportScheduler"
+                "ExportScheduler": "Visualbuilder\\ExportScheduler\\Facades\\ExportScheduler"
             }
         }
     },

--- a/config/export-scheduler.php
+++ b/config/export-scheduler.php
@@ -1,8 +1,8 @@
 <?php
 
-use VisualBuilder\ExportScheduler\Filament\Resources\ExportScheduleResource;
-use VisualBuilder\ExportScheduler\Mail\ExportReady;
-use VisualBuilder\ExportScheduler\Notifications\ScheduledExportCompleteNotification;
+use Visualbuilder\ExportScheduler\Filament\Resources\ExportScheduleResource;
+use Visualbuilder\ExportScheduler\Mail\ExportReady;
+use Visualbuilder\ExportScheduler\Notifications\ScheduledExportCompleteNotification;
 
 return [
 
@@ -51,7 +51,7 @@ return [
              * Change this to your own model maybe \App\Models\User::class
              *
              */
-            'model'           => \VisualBuilder\ExportScheduler\Tests\Models\User::class,
+            'model'           => \Visualbuilder\ExportScheduler\Tests\Models\User::class,
             'title_attribute' => 'email',
         ],
     ],

--- a/database/factories/ExportScheduleFactory.php
+++ b/database/factories/ExportScheduleFactory.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace VisualBuilder\ExportScheduler\Database\Factories;
+namespace Visualbuilder\ExportScheduler\Database\Factories;
 
 use Filament\Actions\Exports\Enums\ExportFormat;
 use Illuminate\Database\Eloquent\Factories\Factory;
-use VisualBuilder\ExportScheduler\Enums\DateRange;
-use VisualBuilder\ExportScheduler\Enums\ScheduleFrequency;
-use VisualBuilder\ExportScheduler\Filament\Exporters\UserExporter;
-use VisualBuilder\ExportScheduler\Models\ExportSchedule;
-use VisualBuilder\ExportScheduler\Tests\Models\User;
+use Visualbuilder\ExportScheduler\Enums\DateRange;
+use Visualbuilder\ExportScheduler\Enums\ScheduleFrequency;
+use Visualbuilder\ExportScheduler\Filament\Exporters\UserExporter;
+use Visualbuilder\ExportScheduler\Models\ExportSchedule;
+use Visualbuilder\ExportScheduler\Tests\Models\User;
 
 
 class ExportScheduleFactory extends Factory

--- a/database/seeders/ExportScheduleSeeder.php
+++ b/database/seeders/ExportScheduleSeeder.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace VisualBuilder\ExportScheduler\Database\Seeders;
+namespace Visualbuilder\ExportScheduler\Database\Seeders;
 
 use Filament\Actions\Exports\Enums\ExportFormat;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
-use VisualBuilder\ExportScheduler\Enums\ScheduleFrequency;
-use VisualBuilder\ExportScheduler\Filament\Exporters\UserExporter;
-use VisualBuilder\ExportScheduler\Tests\Models\User;
+use Visualbuilder\ExportScheduler\Enums\ScheduleFrequency;
+use Visualbuilder\ExportScheduler\Filament\Exporters\UserExporter;
+use Visualbuilder\ExportScheduler\Tests\Models\User;
 
 // Import the Invoice model
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -16,7 +16,7 @@
     backupStaticProperties="false"
 >
     <testsuites>
-        <testsuite name="VisualBuilder Test Suite">
+        <testsuite name="Visualbuilder Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>

--- a/src/Commands/ExportSchedulerCommand.php
+++ b/src/Commands/ExportSchedulerCommand.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace VisualBuilder\ExportScheduler\Commands;
+namespace Visualbuilder\ExportScheduler\Commands;
 
 use Exception;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Log;
-use VisualBuilder\ExportScheduler\Models\ExportSchedule;
-use VisualBuilder\ExportScheduler\Services\ScheduledExporter;
+use Visualbuilder\ExportScheduler\Models\ExportSchedule;
+use Visualbuilder\ExportScheduler\Services\ScheduledExporter;
 
 class ExportSchedulerCommand extends Command
 {

--- a/src/Enums/DateRange.php
+++ b/src/Enums/DateRange.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace VisualBuilder\ExportScheduler\Enums;
+namespace Visualbuilder\ExportScheduler\Enums;
 
 use Carbon\Carbon;
 use Filament\Support\Contracts\HasLabel;

--- a/src/Enums/DayOfWeek.php
+++ b/src/Enums/DayOfWeek.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace VisualBuilder\ExportScheduler\Enums;
+namespace Visualbuilder\ExportScheduler\Enums;
 
 use Carbon\Carbon;
 use Filament\Support\Contracts\HasLabel;

--- a/src/Enums/EnumSubset.php
+++ b/src/Enums/EnumSubset.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace VisualBuilder\ExportScheduler\Enums;
+namespace Visualbuilder\ExportScheduler\Enums;
 
 trait EnumSubset
 {

--- a/src/Enums/Month.php
+++ b/src/Enums/Month.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace VisualBuilder\ExportScheduler\Enums;
+namespace Visualbuilder\ExportScheduler\Enums;
 
 use Filament\Support\Contracts\HasLabel;
 

--- a/src/Enums/ScheduleFrequency.php
+++ b/src/Enums/ScheduleFrequency.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace VisualBuilder\ExportScheduler\Enums;
+namespace Visualbuilder\ExportScheduler\Enums;
 
 use Filament\Support\Contracts\HasLabel;
 

--- a/src/ExportScheduler.php
+++ b/src/ExportScheduler.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace VisualBuilder\ExportScheduler;
+namespace Visualbuilder\ExportScheduler;
 
 use Cron\CronExpression;
 use Illuminate\Support\Facades\File;

--- a/src/ExportSchedulerPlugin.php
+++ b/src/ExportSchedulerPlugin.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace VisualBuilder\ExportScheduler;
+namespace Visualbuilder\ExportScheduler;
 
 use Closure;
 use Filament\Contracts\Plugin;

--- a/src/ExportSchedulerServiceProvider.php
+++ b/src/ExportSchedulerServiceProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace VisualBuilder\ExportScheduler;
+namespace Visualbuilder\ExportScheduler;
 
 use Filament\Actions\Exports\Models\Export;
 use Filament\Support\Assets\Asset;
@@ -8,7 +8,7 @@ use Illuminate\Filesystem\Filesystem;
 use Spatie\LaravelPackageTools\Commands\InstallCommand;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
-use VisualBuilder\ExportScheduler\Commands\ExportSchedulerCommand;
+use Visualbuilder\ExportScheduler\Commands\ExportSchedulerCommand;
 
 class ExportSchedulerServiceProvider extends PackageServiceProvider
 {

--- a/src/Facades/ExportScheduler.php
+++ b/src/Facades/ExportScheduler.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace VisualBuilder\ExportScheduler\Facades;
+namespace Visualbuilder\ExportScheduler\Facades;
 
 use Illuminate\Support\Facades\Facade;
 
 /**
- * @see \VisualBuilder\ExportScheduler\ExportScheduler
+ * @see \Visualbuilder\ExportScheduler\ExportScheduler
  * @method static bool isValidCronExpression(string $expression)
  * @method static array listExporters()
  */
@@ -13,6 +13,6 @@ class ExportScheduler extends Facade
 {
     protected static function getFacadeAccessor()
     {
-        return \VisualBuilder\ExportScheduler\ExportScheduler::class;
+        return \Visualbuilder\ExportScheduler\ExportScheduler::class;
     }
 }

--- a/src/Filament/Actions/RunExport.php
+++ b/src/Filament/Actions/RunExport.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace VisualBuilder\ExportScheduler\Filament\Actions;
+namespace Visualbuilder\ExportScheduler\Filament\Actions;
 
 use Filament\Actions\Action;
 

--- a/src/Filament/Actions/RunExportTrait.php
+++ b/src/Filament/Actions/RunExportTrait.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace VisualBuilder\ExportScheduler\Filament\Actions;
+namespace Visualbuilder\ExportScheduler\Filament\Actions;
 
 use Filament\Notifications\Notification;
 use Filament\Support\Enums\Alignment;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Number;
-use VisualBuilder\ExportScheduler\Models\ExportSchedule;
-use VisualBuilder\ExportScheduler\Services\ScheduledExporter;
+use Visualbuilder\ExportScheduler\Models\ExportSchedule;
+use Visualbuilder\ExportScheduler\Services\ScheduledExporter;
 
 trait RunExportTrait
 {

--- a/src/Filament/Actions/Tables/RunExport.php
+++ b/src/Filament/Actions/Tables/RunExport.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace VisualBuilder\ExportScheduler\Filament\Actions\Tables;
+namespace Visualbuilder\ExportScheduler\Filament\Actions\Tables;
 
 use Filament\Tables\Actions\Action;
-use VisualBuilder\ExportScheduler\Filament\Actions\RunExportTrait;
+use Visualbuilder\ExportScheduler\Filament\Actions\RunExportTrait;
 
 
 class RunExport extends Action

--- a/src/Filament/Exporters/UserExporter.php
+++ b/src/Filament/Exporters/UserExporter.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace VisualBuilder\ExportScheduler\Filament\Exporters;
+namespace Visualbuilder\ExportScheduler\Filament\Exporters;
 
 use Filament\Actions\Exports\ExportColumn;
 use Filament\Actions\Exports\Exporter;
 use Filament\Actions\Exports\Models\Export;
-use VisualBuilder\ExportScheduler\Tests\Models\User;
+use Visualbuilder\ExportScheduler\Tests\Models\User;
 
 class UserExporter extends Exporter
 {

--- a/src/Filament/Forms/Fields.php
+++ b/src/Filament/Forms/Fields.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace VisualBuilder\ExportScheduler\Filament\Forms;
+namespace Visualbuilder\ExportScheduler\Filament\Forms;
 
 use Closure;
 use Filament\Actions\Exports\Enums\ExportFormat;
@@ -21,13 +21,13 @@ use Filament\Forms\Set;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
-use VisualBuilder\ExportScheduler\Enums\DateRange;
-use VisualBuilder\ExportScheduler\Enums\DayOfWeek;
-use VisualBuilder\ExportScheduler\Enums\Month;
-use VisualBuilder\ExportScheduler\Enums\ScheduleFrequency;
-use VisualBuilder\ExportScheduler\Facades\ExportScheduler;
-use VisualBuilder\ExportScheduler\Models\ExportSchedule;
-use VisualBuilder\ExportScheduler\Traits\InteractsWithExportSchedulerFilter;
+use Visualbuilder\ExportScheduler\Enums\DateRange;
+use Visualbuilder\ExportScheduler\Enums\DayOfWeek;
+use Visualbuilder\ExportScheduler\Enums\Month;
+use Visualbuilder\ExportScheduler\Enums\ScheduleFrequency;
+use Visualbuilder\ExportScheduler\Facades\ExportScheduler;
+use Visualbuilder\ExportScheduler\Models\ExportSchedule;
+use Visualbuilder\ExportScheduler\Traits\InteractsWithExportSchedulerFilter;
 
 class Fields
 {

--- a/src/Filament/Forms/Helper.php
+++ b/src/Filament/Forms/Helper.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace VisualBuilder\ExportScheduler\Filament\Forms;
+namespace Visualbuilder\ExportScheduler\Filament\Forms;
 
 use Filament\Forms\Get;
 use Illuminate\Database\Eloquent\Relations\Relation;
-use VisualBuilder\ExportScheduler\Enums\ScheduleFrequency;
+use Visualbuilder\ExportScheduler\Enums\ScheduleFrequency;
 
 class Helper
 {

--- a/src/Filament/Resources/ExportScheduleResource.php
+++ b/src/Filament/Resources/ExportScheduleResource.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace VisualBuilder\ExportScheduler\Filament\Resources;
+namespace Visualbuilder\ExportScheduler\Filament\Resources;
 
 use Filament\Forms\Components\Grid;
 use Filament\Forms\Components\Section;
@@ -11,11 +11,11 @@ use Filament\Pages\SubNavigationPosition;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
-use VisualBuilder\ExportScheduler\ExportSchedulerPlugin;
-use VisualBuilder\ExportScheduler\Filament\Actions\Tables\RunExport;
-use VisualBuilder\ExportScheduler\Filament\Forms\Fields;
-use VisualBuilder\ExportScheduler\Filament\Resources\ExportScheduleResource\Pages;
-use VisualBuilder\ExportScheduler\Models\ExportSchedule;
+use Visualbuilder\ExportScheduler\ExportSchedulerPlugin;
+use Visualbuilder\ExportScheduler\Filament\Actions\Tables\RunExport;
+use Visualbuilder\ExportScheduler\Filament\Forms\Fields;
+use Visualbuilder\ExportScheduler\Filament\Resources\ExportScheduleResource\Pages;
+use Visualbuilder\ExportScheduler\Models\ExportSchedule;
 
 class ExportScheduleResource extends Resource
 {

--- a/src/Filament/Resources/ExportScheduleResource/Pages/CreateExportSchedule.php
+++ b/src/Filament/Resources/ExportScheduleResource/Pages/CreateExportSchedule.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace VisualBuilder\ExportScheduler\Filament\Resources\ExportScheduleResource\Pages;
+namespace Visualbuilder\ExportScheduler\Filament\Resources\ExportScheduleResource\Pages;
 
 use Filament\Resources\Pages\CreateRecord;
-use VisualBuilder\ExportScheduler\Filament\Resources\ExportScheduleResource;
+use Visualbuilder\ExportScheduler\Filament\Resources\ExportScheduleResource;
 
 class CreateExportSchedule extends CreateRecord
 {

--- a/src/Filament/Resources/ExportScheduleResource/Pages/EditExportSchedule.php
+++ b/src/Filament/Resources/ExportScheduleResource/Pages/EditExportSchedule.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace VisualBuilder\ExportScheduler\Filament\Resources\ExportScheduleResource\Pages;
+namespace Visualbuilder\ExportScheduler\Filament\Resources\ExportScheduleResource\Pages;
 
 use Filament\Actions;
 use Filament\Resources\Pages\EditRecord;
-use VisualBuilder\ExportScheduler\Filament\Actions\RunExport;
-use VisualBuilder\ExportScheduler\Filament\Resources\ExportScheduleResource;
+use Visualbuilder\ExportScheduler\Filament\Actions\RunExport;
+use Visualbuilder\ExportScheduler\Filament\Resources\ExportScheduleResource;
 
 class EditExportSchedule extends EditRecord
 {

--- a/src/Filament/Resources/ExportScheduleResource/Pages/ListExportSchedules.php
+++ b/src/Filament/Resources/ExportScheduleResource/Pages/ListExportSchedules.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace VisualBuilder\ExportScheduler\Filament\Resources\ExportScheduleResource\Pages;
+namespace Visualbuilder\ExportScheduler\Filament\Resources\ExportScheduleResource\Pages;
 
 use Filament\Actions;
 use Filament\Resources\Pages\ListRecords;
-use VisualBuilder\ExportScheduler\Filament\Resources\ExportScheduleResource;
+use Visualbuilder\ExportScheduler\Filament\Resources\ExportScheduleResource;
 
 class ListExportSchedules extends ListRecords
 {

--- a/src/Jobs/ExportCsv.php
+++ b/src/Jobs/ExportCsv.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace VisualBuilder\ExportScheduler\Jobs;
+namespace Visualbuilder\ExportScheduler\Jobs;
 
 use AnourValar\EloquentSerialize\Facades\EloquentSerializeFacade;
 use Illuminate\Contracts\Filesystem\Filesystem;

--- a/src/Jobs/PrepareCsvExport.php
+++ b/src/Jobs/PrepareCsvExport.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace VisualBuilder\ExportScheduler\Jobs;
+namespace Visualbuilder\ExportScheduler\Jobs;
 
 use Filament\Actions\Exports\Jobs\PrepareCsvExport as BasePrepareCsvExport;
 

--- a/src/Jobs/ScheduledExportCompletion.php
+++ b/src/Jobs/ScheduledExportCompletion.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace VisualBuilder\ExportScheduler\Jobs;
+namespace Visualbuilder\ExportScheduler\Jobs;
 
 use Filament\Actions\Exports\Models\Export;
 use Illuminate\Bus\Queueable;
@@ -9,7 +9,7 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Log;
-use VisualBuilder\ExportScheduler\Models\ExportSchedule;
+use Visualbuilder\ExportScheduler\Models\ExportSchedule;
 
 class ScheduledExportCompletion implements ShouldQueue
 {

--- a/src/Mail/ExportReady.php
+++ b/src/Mail/ExportReady.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace VisualBuilder\ExportScheduler\Mail;
+namespace Visualbuilder\ExportScheduler\Mail;
 
 use Filament\Actions\Exports\Enums\ExportFormat;
 use Filament\Actions\Exports\Models\Export;
 use Illuminate\Bus\Queueable;
 use Illuminate\Mail\Mailable;
 use Illuminate\Queue\SerializesModels;
-use VisualBuilder\ExportScheduler\Models\ExportSchedule;
+use Visualbuilder\ExportScheduler\Models\ExportSchedule;
 
 class ExportReady extends Mailable
 {

--- a/src/Models/ExportSchedule.php
+++ b/src/Models/ExportSchedule.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace VisualBuilder\ExportScheduler\Models;
+namespace Visualbuilder\ExportScheduler\Models;
 
 use Carbon\Carbon;
 use Cron\CronExpression;
@@ -11,10 +11,10 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Support\Collection;
-use VisualBuilder\ExportScheduler\Enums\DateRange;
-use VisualBuilder\ExportScheduler\Enums\DayOfWeek;
-use VisualBuilder\ExportScheduler\Enums\Month;
-use VisualBuilder\ExportScheduler\Enums\ScheduleFrequency;
+use Visualbuilder\ExportScheduler\Enums\DateRange;
+use Visualbuilder\ExportScheduler\Enums\DayOfWeek;
+use Visualbuilder\ExportScheduler\Enums\Month;
+use Visualbuilder\ExportScheduler\Enums\ScheduleFrequency;
 
 /**
  * App\Models\ExportSchedule

--- a/src/Notifications/ScheduledExportCompleteNotification.php
+++ b/src/Notifications/ScheduledExportCompleteNotification.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace VisualBuilder\ExportScheduler\Notifications;
+namespace Visualbuilder\ExportScheduler\Notifications;
 
 use Filament\Actions\Exports\Models\Export;
 use Illuminate\Bus\Queueable;
@@ -11,7 +11,7 @@ use Illuminate\Notifications\Notification;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Log;
 use InvalidArgumentException;
-use VisualBuilder\ExportScheduler\Models\ExportSchedule;
+use Visualbuilder\ExportScheduler\Models\ExportSchedule;
 
 // implements ShouldQueue
 

--- a/src/Services/ScheduledExporter.php
+++ b/src/Services/ScheduledExporter.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace VisualBuilder\ExportScheduler\Services;
+namespace Visualbuilder\ExportScheduler\Services;
 
 use AnourValar\EloquentSerialize\Facades\EloquentSerializeFacade;
 use Filament\Actions\Exports\Enums\ExportFormat;
@@ -14,10 +14,10 @@ use Illuminate\Foundation\Bus\PendingChain;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
-use VisualBuilder\ExportScheduler\Enums\DateRange;
-use VisualBuilder\ExportScheduler\Jobs\PrepareCsvExport;
-use VisualBuilder\ExportScheduler\Jobs\ScheduledExportCompletion;
-use VisualBuilder\ExportScheduler\Models\ExportSchedule;
+use Visualbuilder\ExportScheduler\Enums\DateRange;
+use Visualbuilder\ExportScheduler\Jobs\PrepareCsvExport;
+use Visualbuilder\ExportScheduler\Jobs\ScheduledExportCompletion;
+use Visualbuilder\ExportScheduler\Models\ExportSchedule;
 
 class ScheduledExporter
 {

--- a/src/Support/MorphToSelectHelper.php
+++ b/src/Support/MorphToSelectHelper.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace VisualBuilder\ExportScheduler\Support;
+namespace Visualbuilder\ExportScheduler\Support;
 
 use Filament\Forms\Components\MorphToSelect;
 

--- a/src/Testing/TestsExportScheduler.php
+++ b/src/Testing/TestsExportScheduler.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace VisualBuilder\ExportScheduler\Testing;
+namespace Visualbuilder\ExportScheduler\Testing;
 
 use Livewire\Features\SupportTesting\Testable;
 

--- a/src/Traits/InteractsWithExportSchedulerFilter.php
+++ b/src/Traits/InteractsWithExportSchedulerFilter.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace VisualBuilder\ExportScheduler\Traits;
+namespace Visualbuilder\ExportScheduler\Traits;
 
 trait InteractsWithExportSchedulerFilter
 {

--- a/tests/AdminPanelProvider.php
+++ b/tests/AdminPanelProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace VisualBuilder\ExportScheduler\Tests;
+namespace Visualbuilder\ExportScheduler\Tests;
 
 use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\DisableBladeIconComponents;
@@ -15,7 +15,7 @@ use Illuminate\Routing\Middleware\SubstituteBindings;
 use Illuminate\Session\Middleware\AuthenticateSession;
 use Illuminate\Session\Middleware\StartSession;
 use Illuminate\View\Middleware\ShareErrorsFromSession;
-use VisualBuilder\ExportScheduler\ExportSchedulerPlugin;
+use Visualbuilder\ExportScheduler\ExportSchedulerPlugin;
 
 class AdminPanelProvider extends PanelProvider
 {

--- a/tests/Exporters/DocumentExporter.php
+++ b/tests/Exporters/DocumentExporter.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace VisualBuilder\ExportScheduler\Tests\Exporters;
+namespace Visualbuilder\ExportScheduler\Tests\Exporters;
 
 use Filament\Actions\Exports\ExportColumn;
 use Filament\Actions\Exports\Exporter;
 use Filament\Actions\Exports\Models\Export;
-use VisualBuilder\ExportScheduler\Tests\Models\Document;
+use Visualbuilder\ExportScheduler\Tests\Models\Document;
 
 class DocumentExporter extends Exporter
 {

--- a/tests/Exporters/DocumentOwnerExporter.php
+++ b/tests/Exporters/DocumentOwnerExporter.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace VisualBuilder\ExportScheduler\Tests\Exporters;
+namespace Visualbuilder\ExportScheduler\Tests\Exporters;
 
 use Filament\Actions\Exports\ExportColumn;
 use Filament\Actions\Exports\Exporter;
 use Filament\Actions\Exports\Models\Export;
-use VisualBuilder\ExportScheduler\Tests\Models\Document;
+use Visualbuilder\ExportScheduler\Tests\Models\Document;
 
 class DocumentOwnerExporter extends Exporter
 {

--- a/tests/Feature/FrequencyTest.php
+++ b/tests/Feature/FrequencyTest.php
@@ -3,12 +3,12 @@
 use Carbon\Carbon;
 use Filament\Actions\Exports\Enums\ExportFormat;
 use Illuminate\Support\Facades\Notification;
-use VisualBuilder\ExportScheduler\Enums\DayOfWeek;
-use VisualBuilder\ExportScheduler\Enums\Month;
-use VisualBuilder\ExportScheduler\Enums\ScheduleFrequency;
-use VisualBuilder\ExportScheduler\Filament\Exporters\UserExporter;
-use VisualBuilder\ExportScheduler\Models\ExportSchedule;
-use VisualBuilder\ExportScheduler\Notifications\ScheduledExportCompleteNotification;
+use Visualbuilder\ExportScheduler\Enums\DayOfWeek;
+use Visualbuilder\ExportScheduler\Enums\Month;
+use Visualbuilder\ExportScheduler\Enums\ScheduleFrequency;
+use Visualbuilder\ExportScheduler\Filament\Exporters\UserExporter;
+use Visualbuilder\ExportScheduler\Models\ExportSchedule;
+use Visualbuilder\ExportScheduler\Notifications\ScheduledExportCompleteNotification;
 
 beforeEach(function () {
     Notification::fake();

--- a/tests/Feature/MorphToFilterTest.php
+++ b/tests/Feature/MorphToFilterTest.php
@@ -1,12 +1,12 @@
 <?php
 
-use VisualBuilder\ExportScheduler\Enums\ScheduleFrequency;
-use VisualBuilder\ExportScheduler\Models\ExportSchedule;
-use VisualBuilder\ExportScheduler\Services\ScheduledExporter;
-use VisualBuilder\ExportScheduler\Tests\Exporters\DocumentExporter;
-use VisualBuilder\ExportScheduler\Tests\Models\Contact;
-use VisualBuilder\ExportScheduler\Tests\Models\Document;
-use VisualBuilder\ExportScheduler\Tests\Models\Organisation;
+use Visualbuilder\ExportScheduler\Enums\ScheduleFrequency;
+use Visualbuilder\ExportScheduler\Models\ExportSchedule;
+use Visualbuilder\ExportScheduler\Services\ScheduledExporter;
+use Visualbuilder\ExportScheduler\Tests\Exporters\DocumentExporter;
+use Visualbuilder\ExportScheduler\Tests\Models\Contact;
+use Visualbuilder\ExportScheduler\Tests\Models\Document;
+use Visualbuilder\ExportScheduler\Tests\Models\Organisation;
 
 it('applies attribute filter on nested MorphTo relation', function () {
     $contact = Contact::create(['full_name' => 'John Doe']);

--- a/tests/Feature/NestedDateTimeFilterTest.php
+++ b/tests/Feature/NestedDateTimeFilterTest.php
@@ -1,12 +1,12 @@
 <?php
 
-use VisualBuilder\ExportScheduler\Enums\ScheduleFrequency;
-use VisualBuilder\ExportScheduler\Models\ExportSchedule;
-use VisualBuilder\ExportScheduler\Services\ScheduledExporter;
-use VisualBuilder\ExportScheduler\Tests\Exporters\DocumentOwnerExporter;
-use VisualBuilder\ExportScheduler\Tests\Models\Contact;
-use VisualBuilder\ExportScheduler\Tests\Models\Document;
-use VisualBuilder\ExportScheduler\Tests\Models\Organisation;
+use Visualbuilder\ExportScheduler\Enums\ScheduleFrequency;
+use Visualbuilder\ExportScheduler\Models\ExportSchedule;
+use Visualbuilder\ExportScheduler\Services\ScheduledExporter;
+use Visualbuilder\ExportScheduler\Tests\Exporters\DocumentOwnerExporter;
+use Visualbuilder\ExportScheduler\Tests\Models\Contact;
+use Visualbuilder\ExportScheduler\Tests\Models\Document;
+use Visualbuilder\ExportScheduler\Tests\Models\Organisation;
 
 it('detects chained datetime attributes', function () {
     $contact = Contact::create(['full_name' => 'John Doe']);

--- a/tests/Models/Contact.php
+++ b/tests/Models/Contact.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace VisualBuilder\ExportScheduler\Tests\Models;
+namespace Visualbuilder\ExportScheduler\Tests\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;

--- a/tests/Models/Document.php
+++ b/tests/Models/Document.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace VisualBuilder\ExportScheduler\Tests\Models;
+namespace Visualbuilder\ExportScheduler\Tests\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;

--- a/tests/Models/Organisation.php
+++ b/tests/Models/Organisation.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace VisualBuilder\ExportScheduler\Tests\Models;
+namespace Visualbuilder\ExportScheduler\Tests\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;

--- a/tests/Models/User.php
+++ b/tests/Models/User.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace VisualBuilder\ExportScheduler\Tests\Models;
+namespace Visualbuilder\ExportScheduler\Tests\Models;
 
 use Filament\Models\Contracts\FilamentUser;
 use Filament\Panel;

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,6 +1,6 @@
 <?php
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use VisualBuilder\ExportScheduler\Tests\TestCase;
+use Visualbuilder\ExportScheduler\Tests\TestCase;
 
 uses(TestCase::class)->in('Feature');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace VisualBuilder\ExportScheduler\Tests;
+namespace Visualbuilder\ExportScheduler\Tests;
 
 use BladeUI\Heroicons\BladeHeroiconsServiceProvider;
 use BladeUI\Icons\BladeIconsServiceProvider;
@@ -15,9 +15,9 @@ use Filament\Widgets\WidgetsServiceProvider;
 use Livewire\LivewireServiceProvider;
 use Orchestra\Testbench\TestCase as Orchestra;
 use RyanChandler\BladeCaptureDirective\BladeCaptureDirectiveServiceProvider;
-use VisualBuilder\ExportScheduler\ExportSchedulerServiceProvider;
-use VisualBuilder\ExportScheduler\Tests\Models\User;
-use VisualBuilder\ExportScheduler\Tests\Traits\CustomRefreshDatabase;
+use Visualbuilder\ExportScheduler\ExportSchedulerServiceProvider;
+use Visualbuilder\ExportScheduler\Tests\Models\User;
+use Visualbuilder\ExportScheduler\Tests\Traits\CustomRefreshDatabase;
 
 class TestCase extends Orchestra
 {

--- a/tests/Traits/CustomRefreshDatabase.php
+++ b/tests/Traits/CustomRefreshDatabase.php
@@ -1,7 +1,7 @@
 <?php
 
 
-namespace VisualBuilder\ExportScheduler\Tests\Traits;
+namespace Visualbuilder\ExportScheduler\Tests\Traits;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 


### PR DESCRIPTION
## Summary
- rename VisualBuilder namespace references to Visualbuilder
- update configs, docs, and phpunit suite names

## Testing
- `composer install --no-interaction --no-progress`
- `composer test` *(fails: SQLSTATE[HY000] [2002] Connection refused)*
- `composer analyse -- --memory-limit=512M` *(fails: Ignored error pattern not matched)*

------
https://chatgpt.com/codex/tasks/task_e_68926286ebbc8333b8bc4016138a8bdb