### PR TITLE
fix: new scheduled exports not running when due

### DIFF
--- a/src/Models/ExportSchedule.php
+++ b/src/Models/ExportSchedule.php
@@ -134,7 +134,9 @@ class ExportSchedule extends Model
     protected static function booted()
     {
         self::creating(function (ExportSchedule $exportSchedule) {
-            $exportSchedule->next_run_at = $exportSchedule->calculateNextRun();
+            if (is_null($exportSchedule->next_run_at)) {
+                $exportSchedule->next_run_at = $exportSchedule->calculateNextRun();
+            }
         });
     }
 

--- a/src/Models/ExportSchedule.php
+++ b/src/Models/ExportSchedule.php
@@ -131,6 +131,13 @@ class ExportSchedule extends Model
         'filters' => 'array',
     ];
 
+    protected static function booted()
+    {
+        self::creating(function (ExportSchedule $exportSchedule) {
+            $exportSchedule->next_run_at = $exportSchedule->calculateNextRun();
+        });
+    }
+
     public function owner(): MorphTo
     {
         return $this->morphTo();


### PR DESCRIPTION
When a new ExportSchedule is created, the 'next_run_at' attribute is set to null by default which is needed to run the scheduled export automatically when it is enabled and due.

This fix addresses that issue by setting it when the ExportSchedule is been created.