### PR TITLE
fix scheduled CSV export for Filament 4

### DIFF
--- a/src/Jobs/ExportCsv.php
+++ b/src/Jobs/ExportCsv.php
@@ -3,18 +3,23 @@
 namespace Visualbuilder\ExportScheduler\Jobs;
 
 use AnourValar\EloquentSerialize\Facades\EloquentSerializeFacade;
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Filesystem\Filesystem;
+use Illuminate\Database\Query\Expression;
 use Illuminate\Support\Facades\DB;
 use League\Csv\Writer;
 use SplTempFileObject;
 use Throwable;
-use  Filament\Actions\Exports\Jobs\ExportCsv as BaseExportCsv;
+use Filament\Actions\Exports\Jobs\ExportCsv as BaseExportCsv;
 
 class ExportCsv extends BaseExportCsv
 {
     public function handle(): void
     {
-        auth()->setUser($this->export->user);
+        /** @var Authenticatable $user */
+        $user = $this->export->user;
+
+        auth()->setUser($user);
 
         $processedRows = 0;
         $successfulRows = 0;
@@ -32,38 +37,43 @@ class ExportCsv extends BaseExportCsv
         foreach ($query->find($this->records) as $record) {
             try {
                 $csv->insertOne(($this->exporter)($record));
+
                 $successfulRows++;
             } catch (Throwable $exception) {
-                $exceptions[$exception::class] = $exception;
+                report($exception);
             }
 
             $processedRows++;
         }
 
         $filePath = $this->export->getFileDirectory() . DIRECTORY_SEPARATOR . str_pad(strval($this->page), 16, '0', STR_PAD_LEFT) . '.csv';
-        $this->export->getFileDisk()->put($filePath, $csv->toString(), Filesystem::VISIBILITY_PRIVATE);
 
-        $this->export::query()
-            ->whereKey($this->export->getKey())
-            ->update([
-                'processed_rows' => DB::raw('processed_rows + ' . $processedRows),
-                'successful_rows' => DB::raw('successful_rows + ' . $successfulRows),
-            ]);
+        DB::transaction(function () use ($csv, $filePath, $processedRows, $successfulRows): void {
+            $this->export::query()
+                ->whereKey($this->export->getKey())
+                ->lockForUpdate()
+                ->update([
+                    'processed_rows' => new Expression('processed_rows + ' . $processedRows),
+                    'successful_rows' => new Expression('successful_rows + ' . $successfulRows),
+                ]);
 
-        $this->export::query()
-            ->whereKey($this->export->getKey())
-            ->whereColumn('processed_rows', '>', 'total_rows')
-            ->update([
-                'processed_rows' => DB::raw('total_rows'),
-            ]);
+            $this->export::query()
+                ->whereKey($this->export->getKey())
+                ->whereColumn('processed_rows', '>', 'total_rows')
+                ->lockForUpdate()
+                ->update([
+                    'processed_rows' => new Expression('total_rows'),
+                ]);
 
-        $this->export::query()
-            ->whereKey($this->export->getKey())
-            ->whereColumn('successful_rows', '>', 'total_rows')
-            ->update([
-                'successful_rows' => DB::raw('total_rows'),
-            ]);
+            $this->export::query()
+                ->whereKey($this->export->getKey())
+                ->whereColumn('successful_rows', '>', 'total_rows')
+                ->lockForUpdate()
+                ->update([
+                    'successful_rows' => new Expression('total_rows'),
+                ]);
 
-        $this->handleExceptions($exceptions ?? []);
+            $this->export->getFileDisk()->put($filePath, $csv->toString(), Filesystem::VISIBILITY_PRIVATE);
+        });
     }
 }


### PR DESCRIPTION
## Summary
- update ExportCsv job to use Filament 4's error handling and transaction-based row updates

## Testing
- `composer test` *(fails: Call to undefined method PDO::connect)*
- `composer analyse` *(fails: Allowed memory size exhausted)*

------
https://chatgpt.com/codex/tasks/task_e_68a48845408883338aef442cdca479c3