### PR TITLE
feat: add SQL query option for scheduled reports (NB-523)

### DIFF
--- a/config/export-scheduler.php
+++ b/config/export-scheduler.php
@@ -25,6 +25,14 @@ return [
     ],
 
     'file_disk' => 'local',
+
+    /**
+     * Roles allowed to create SQL query reports.
+     * Uses Spatie Permission hasRole() check.
+     * Set to empty array to allow all users.
+     */
+    'sql_query_roles' => ['Developer'],
+
     /**
      * Admin Panel Navigation
      * See also Plugin options

--- a/database/factories/ExportScheduleFactory.php
+++ b/database/factories/ExportScheduleFactory.php
@@ -5,6 +5,7 @@ namespace Visualbuilder\ExportScheduler\Database\Factories;
 use Filament\Actions\Exports\Enums\ExportFormat;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Visualbuilder\ExportScheduler\Enums\DateRange;
+use Visualbuilder\ExportScheduler\Enums\ReportType;
 use Visualbuilder\ExportScheduler\Enums\ScheduleFrequency;
 use Visualbuilder\ExportScheduler\Filament\Exporters\UserExporter;
 use Visualbuilder\ExportScheduler\Models\ExportSchedule;
@@ -27,6 +28,7 @@ class ExportScheduleFactory extends Factory
     {
         return [
             'name'                   => $this->faker->sentence(3),
+            'report_type'            => ReportType::EXPORTER,
             'exporter'               => UserExporter::class,
             'columns'                => json_encode([
                 [

--- a/database/migrations/2024_01_01_000000_create_export_scheduler_table.php.stub
+++ b/database/migrations/2024_01_01_000000_create_export_scheduler_table.php.stub
@@ -16,7 +16,7 @@ return new class extends Migration
             Schema::create('export_schedules', function (Blueprint $table) {
                 $table->increments('id');
                 $table->string('name', 191);
-                $table->string('exporter', 191); //The base Filament Exporter Class
+                $table->string('exporter', 191)->nullable(); //The base Filament Exporter Class (nullable for SQL query reports)
                 $table->json('columns')->nullable(); // An array of columns to override the Exporter class columns
                 $table->json('filters')->nullable(); // A key-value array of the selected relations and their respective values
                 $table->string('schedule_frequency');

--- a/database/migrations/2024_01_01_000002_add_sql_query_columns_to_export_schedules_table.php.stub
+++ b/database/migrations/2024_01_01_000002_add_sql_query_columns_to_export_schedules_table.php.stub
@@ -15,6 +15,8 @@ return new class extends Migration
             if (! Schema::hasColumn('export_schedules', 'sql_query')) {
                 $table->text('sql_query')->nullable()->after('report_type');
             }
+            // Make exporter nullable so SQL query reports don't require it
+            $table->string('exporter', 191)->nullable()->change();
         });
     }
 

--- a/database/migrations/2024_01_01_000002_add_sql_query_columns_to_export_schedules_table.php.stub
+++ b/database/migrations/2024_01_01_000002_add_sql_query_columns_to_export_schedules_table.php.stub
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('export_schedules', function (Blueprint $table) {
+            if (! Schema::hasColumn('export_schedules', 'report_type')) {
+                $table->string('report_type', 20)->default('exporter')->after('name');
+            }
+            if (! Schema::hasColumn('export_schedules', 'sql_query')) {
+                $table->text('sql_query')->nullable()->after('report_type');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('export_schedules', function (Blueprint $table) {
+            $table->dropColumn(['report_type', 'sql_query']);
+        });
+    }
+};

--- a/src/Enums/ReportType.php
+++ b/src/Enums/ReportType.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Visualbuilder\ExportScheduler\Enums;
+
+use Filament\Support\Contracts\HasLabel;
+
+enum ReportType: string implements HasLabel
+{
+    case EXPORTER = 'exporter';
+    case SQL_QUERY = 'sql_query';
+
+    public function getLabel(): ?string
+    {
+        return match ($this) {
+            self::EXPORTER => 'Exporter',
+            self::SQL_QUERY => 'SQL Query',
+        };
+    }
+}

--- a/src/Filament/Forms/Fields.php
+++ b/src/Filament/Forms/Fields.php
@@ -21,9 +21,11 @@ use Filament\Schemas\Components\Utilities\Set;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
+use Filament\Forms\Components\Textarea;
 use Visualbuilder\ExportScheduler\Enums\DateRange;
 use Visualbuilder\ExportScheduler\Enums\DayOfWeek;
 use Visualbuilder\ExportScheduler\Enums\Month;
+use Visualbuilder\ExportScheduler\Enums\ReportType;
 use Visualbuilder\ExportScheduler\Enums\ScheduleFrequency;
 use Visualbuilder\ExportScheduler\Facades\ExportScheduler;
 use Visualbuilder\ExportScheduler\Models\ExportSchedule;
@@ -40,12 +42,54 @@ class Fields
             ->maxLength(191);
     }
 
+    public static function reportType(): Select
+    {
+        return Select::make('report_type')
+            ->label('Report Type')
+            ->options(ReportType::class)
+            ->default(ReportType::EXPORTER->value)
+            ->required()
+            ->native(false)
+            ->live()
+            ->afterStateUpdated(function (Set $set, $state) {
+                if ($state === ReportType::SQL_QUERY->value) {
+                    $set('exporter', null);
+                    $set('columns', []);
+                    $set('available_columns', []);
+                } else {
+                    $set('sql_query', null);
+                }
+            });
+    }
+
+    public static function sqlQuery(): Textarea
+    {
+        return Textarea::make('sql_query')
+            ->label('SQL Query')
+            ->placeholder("SELECT column1, column2\nFROM table_name\nWHERE condition\nORDER BY column1")
+            ->rows(8)
+            ->required(fn (Get $get) => $get('report_type') === ReportType::SQL_QUERY->value)
+            ->visible(fn (Get $get) => $get('report_type') === ReportType::SQL_QUERY->value)
+            ->helperText('Enter a SELECT query only. INSERT, UPDATE, DELETE, DROP and other write operations are blocked.')
+            ->rules([
+                fn (): Closure => function (string $attribute, $value, Closure $fail) {
+                    if (blank($value)) {
+                        return;
+                    }
+                    $errors = ExportSchedule::validateSqlQuery($value);
+                    foreach ($errors as $error) {
+                        $fail($error);
+                    }
+                },
+            ]);
+    }
+
     public static function filterReportSection(): Section
     {
         return Section::make('Filter By Associated Records (optional)')
             ->columns()
             ->live()
-            ->visible(fn (Get $get) => $get('exporter'))
+            ->visible(fn (Get $get) => $get('exporter') && ($get('report_type') ?? ReportType::EXPORTER->value) !== ReportType::SQL_QUERY->value)
             ->schema([
                 // Section for choosing which relation types to filter by.
                 Section::make('Choose the Associated Record Type')
@@ -183,7 +227,7 @@ class Fields
     {
         return Section::make('Filter By Attributes (optional)')
             ->live()
-            ->visible(fn (Get $get) => $get('exporter'))
+            ->visible(fn (Get $get) => $get('exporter') && ($get('report_type') ?? ReportType::EXPORTER->value) !== ReportType::SQL_QUERY->value)
             ->schema(function (Get $get) {
                 $exporterClass = $get('exporter');
                 $columns = ExportSchedule::getDefaultColumnsForExporter($exporterClass ?? '')
@@ -381,7 +425,8 @@ class Fields
             ->searchable()
             ->native(false)
             ->live()
-            ->required()
+            ->visible(fn (Get $get) => ($get('report_type') ?? ReportType::EXPORTER->value) !== ReportType::SQL_QUERY->value)
+            ->required(fn (Get $get) => ($get('report_type') ?? ReportType::EXPORTER->value) !== ReportType::SQL_QUERY->value)
             ->afterStateUpdated(function (?ExportSchedule $record, $state, Set $set, $livewire) {
                 /** Clear any existing selected_relations & filter data */
                 if (array_key_exists('filters', $livewire->data)) {

--- a/src/Filament/Forms/Fields.php
+++ b/src/Filament/Forms/Fields.php
@@ -42,15 +42,31 @@ class Fields
             ->maxLength(191);
     }
 
+    public static function canUseSqlQuery(): bool
+    {
+        $roles = config('export-scheduler.sql_query_roles', []);
+
+        if (empty($roles)) {
+            return true;
+        }
+
+        $user = auth()->user();
+
+        return $user && method_exists($user, 'hasRole') && $user->hasRole($roles);
+    }
+
     public static function reportType(): Select
     {
         return Select::make('report_type')
             ->label('Report Type')
-            ->options(ReportType::class)
+            ->options(fn () => self::canUseSqlQuery()
+                ? ReportType::class
+                : [ReportType::EXPORTER->value => ReportType::EXPORTER->getLabel()])
             ->default(ReportType::EXPORTER->value)
             ->required()
             ->native(false)
             ->live()
+            ->visible(fn (?ExportSchedule $record) => self::canUseSqlQuery() || $record?->isSqlQuery())
             ->afterStateUpdated(function (Set $set, $state) {
                 if ($state === ReportType::SQL_QUERY->value) {
                     $set('exporter', null);

--- a/src/Filament/Resources/ExportScheduleResource.php
+++ b/src/Filament/Resources/ExportScheduleResource.php
@@ -70,6 +70,7 @@ namespace Visualbuilder\ExportScheduler\Filament\Resources {
                 ->schema([
                     Tabs::make('tabs')->tabs([
                         Tabs\Tab::make('Exporter')
+                            ->label(fn (Get $get) => ($get('report_type') ?? 'exporter') === 'sql_query' ? 'SQL Query' : 'Exporter')
                             ->schema([
                                 Section::make()
                                     ->columnSpanFull()
@@ -77,13 +78,15 @@ namespace Visualbuilder\ExportScheduler\Filament\Resources {
                                         Grid::make()
                                             ->schema([
                                                 Fields::name(),
-                                                Fields::exporter(),
+                                                Fields::reportType(),
                                             ])
                                             ->columns(1)
                                             ->columnSpan(1),
 
                                         Grid::make()
                                             ->schema([
+                                                Fields::exporter(),
+                                                Fields::sqlQuery(),
                                                 Fields::ownerMorphSelect(),
                                             ])
                                             ->columns(1)
@@ -139,7 +142,7 @@ namespace Visualbuilder\ExportScheduler\Filament\Resources {
                                 Fields::columnsRepeater(),
                             ])
                             ->columns(4)
-                            ->visible(fn (Get $get) => $get('exporter') ? ExportSchedule::getDefaultColumnsForExporter($get('exporter'))->count() : false)
+                            ->visible(fn (Get $get) => ($get('report_type') ?? 'exporter') !== 'sql_query' && $get('exporter') && ExportSchedule::getDefaultColumnsForExporter($get('exporter'))->count())
                             ->extraAttributes(['class' => 'column_picker']),
                     ])
                         ->contained(false)
@@ -155,6 +158,7 @@ namespace Visualbuilder\ExportScheduler\Filament\Resources {
                 ->columns([
                     Tables\Columns\TextColumn::make('id'),
                     Tables\Columns\TextColumn::make('name')->label(__('export-scheduler::scheduler.name')),
+                    Tables\Columns\TextColumn::make('report_type')->label('Type')->badge(),
                     Tables\Columns\TextColumn::make('schedule_frequency')->label(__('export-scheduler::scheduler.schedule_frequency'))->badge(),
                     Tables\Columns\TextColumn::make('date_range')->label(__('export-scheduler::scheduler.date_range'))->badge()->color('warning'),
                     Tables\Columns\TextColumn::make('owner.email')->label(__('export-scheduler::scheduler.recipient')),

--- a/src/Jobs/ExportSqlQuery.php
+++ b/src/Jobs/ExportSqlQuery.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Visualbuilder\ExportScheduler\Jobs;
+
+use Filament\Actions\Exports\Models\Export;
+use Illuminate\Bus\Batchable;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Filesystem\Filesystem;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Query\Expression;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\DB;
+use League\Csv\Writer;
+use SplTempFileObject;
+use Throwable;
+
+class ExportSqlQuery implements ShouldQueue
+{
+    use Batchable;
+    use Dispatchable;
+    use Queueable;
+    use SerializesModels;
+
+    public function __construct(
+        protected Export $export,
+        protected string $sql,
+    ) {}
+
+    public function handle(): void
+    {
+        $results = DB::select($this->sql);
+
+        if (empty($results)) {
+            DB::transaction(function (): void {
+                $this->export::query()
+                    ->whereKey($this->export->getKey())
+                    ->lockForUpdate()
+                    ->update([
+                        'processed_rows' => 0,
+                        'successful_rows' => 0,
+                        'total_rows' => 0,
+                    ]);
+            });
+
+            return;
+        }
+
+        $csv = Writer::createFromFileObject(new SplTempFileObject);
+
+        // Write header row from column names
+        $csv->insertOne(array_keys((array) $results[0]));
+
+        $processedRows = 0;
+        $successfulRows = 0;
+
+        foreach ($results as $row) {
+            try {
+                $csv->insertOne(array_values((array) $row));
+                $successfulRows++;
+            } catch (Throwable $exception) {
+                report($exception);
+            }
+            $processedRows++;
+        }
+
+        $filePath = $this->export->getFileDirectory() . DIRECTORY_SEPARATOR . '0000000000000001.csv';
+
+        DB::transaction(function () use ($csv, $filePath, $processedRows, $successfulRows): void {
+            $this->export::query()
+                ->whereKey($this->export->getKey())
+                ->lockForUpdate()
+                ->update([
+                    'processed_rows' => $processedRows,
+                    'successful_rows' => $successfulRows,
+                    'total_rows' => $processedRows,
+                ]);
+
+            $this->export->getFileDisk()->put($filePath, $csv->toString(), Filesystem::VISIBILITY_PRIVATE);
+        });
+    }
+}

--- a/src/Models/ExportSchedule.php
+++ b/src/Models/ExportSchedule.php
@@ -142,6 +142,20 @@ class ExportSchedule extends Model
     protected static function booted()
     {
         self::saving(function (ExportSchedule $exportSchedule) {
+            // Prevent non-developers from saving SQL query reports
+            if ($exportSchedule->isDirty('report_type')
+                && $exportSchedule->report_type === ReportType::SQL_QUERY
+            ) {
+                $roles = config('export-scheduler.sql_query_roles', []);
+                $user = auth()->user();
+
+                if (! empty($roles) && $user && method_exists($user, 'hasRole') && ! $user->hasRole($roles)) {
+                    throw new \Illuminate\Auth\Access\AuthorizationException(
+                        'You do not have permission to create SQL query reports.'
+                    );
+                }
+            }
+
             if (is_null($exportSchedule->next_run_at)) {
                 $exportSchedule->next_run_at = $exportSchedule->calculateNextRun();
             }

--- a/src/Models/ExportSchedule.php
+++ b/src/Models/ExportSchedule.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Collection;
 use Visualbuilder\ExportScheduler\Enums\DateRange;
 use Visualbuilder\ExportScheduler\Enums\DayOfWeek;
 use Visualbuilder\ExportScheduler\Enums\Month;
+use Visualbuilder\ExportScheduler\Enums\ReportType;
 use Visualbuilder\ExportScheduler\Enums\ScheduleFrequency;
 
 /**
@@ -84,6 +85,8 @@ class ExportSchedule extends Model
      */
     protected $fillable = [
         'name',
+        'report_type',
+        'sql_query',
         'columns',
         'exporter',
         'date_range',
@@ -127,8 +130,13 @@ class ExportSchedule extends Model
         'schedule_month' => Month::class,
         'schedule_start_month' => Month::class,
         'date_range' => DateRange::class,
+        'report_type' => ReportType::class,
         'schedule_frequency' => ScheduleFrequency::class,
         'filters' => 'array',
+    ];
+
+    protected $attributes = [
+        'report_type' => 'exporter',
     ];
 
     protected static function booted()
@@ -402,6 +410,45 @@ class ExportSchedule extends Model
         }
 
         return true;
+    }
+
+    public function isSqlQuery(): bool
+    {
+        return $this->report_type === ReportType::SQL_QUERY;
+    }
+
+    /**
+     * Validate that the SQL query is a safe SELECT statement.
+     */
+    public static function validateSqlQuery(string $sql): array
+    {
+        $errors = [];
+        $normalised = preg_replace('/\s+/', ' ', trim($sql));
+
+        if (! preg_match('/^\s*SELECT\b/i', $normalised)) {
+            $errors[] = 'Query must begin with SELECT.';
+        }
+
+        $dangerous = [
+            'INSERT', 'UPDATE', 'DELETE', 'DROP', 'ALTER', 'CREATE', 'TRUNCATE',
+            'REPLACE', 'RENAME', 'GRANT', 'REVOKE', 'EXEC', 'EXECUTE',
+            'INTO\s+OUTFILE', 'INTO\s+DUMPFILE', 'LOAD_FILE',
+        ];
+
+        foreach ($dangerous as $keyword) {
+            if (preg_match('/\b' . $keyword . '\b/i', $normalised)) {
+                $errors[] = "Prohibited keyword detected: " . str_replace('\\s+', ' ', $keyword);
+            }
+        }
+
+        // Block multiple statements
+        $withoutStrings = preg_replace("/'[^']*'/", '', $normalised);
+        $withoutStrings = preg_replace('/"[^"]*"/', '', $withoutStrings);
+        if (substr_count($withoutStrings, ';') > 1) {
+            $errors[] = 'Multiple statements are not allowed.';
+        }
+
+        return $errors;
     }
 
     public function getCcCountAttribute(): int

--- a/src/Models/ExportSchedule.php
+++ b/src/Models/ExportSchedule.php
@@ -441,11 +441,11 @@ class ExportSchedule extends Model
             }
         }
 
-        // Block multiple statements
+        // Block any semicolons — they break subquery wrapping and could enable injection
         $withoutStrings = preg_replace("/'[^']*'/", '', $normalised);
         $withoutStrings = preg_replace('/"[^"]*"/', '', $withoutStrings);
-        if (substr_count($withoutStrings, ';') > 1) {
-            $errors[] = 'Multiple statements are not allowed.';
+        if (str_contains($withoutStrings, ';')) {
+            $errors[] = 'Semicolons are not allowed in the query.';
         }
 
         return $errors;

--- a/src/Services/ScheduledExporter.php
+++ b/src/Services/ScheduledExporter.php
@@ -12,9 +12,11 @@ use Illuminate\Bus\PendingBatch;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Foundation\Bus\PendingChain;
 use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Visualbuilder\ExportScheduler\Enums\DateRange;
+use Visualbuilder\ExportScheduler\Jobs\ExportSqlQuery;
 use Visualbuilder\ExportScheduler\Jobs\PrepareCsvExport;
 use Visualbuilder\ExportScheduler\Jobs\ScheduledExportCompletion;
 use Visualbuilder\ExportScheduler\Models\ExportSchedule;
@@ -157,6 +159,10 @@ class ScheduledExporter
 
     public function run(): bool
     {
+        if ($this->exportSchedule->isSqlQuery()) {
+            return $this->initSqlQuery() && $this->buildSqlQueryJobChain();
+        }
+
         if ($this->exportSchedule->dynamic_owner_enabled && $this->exportSchedule->dynamic_owner_attribute) {
             $baseQuery = $this->buildBaseQuery();
             $owners = $baseQuery->get()
@@ -244,6 +250,69 @@ class ScheduledExporter
         }
 
         return $types->unique()->all();
+    }
+
+    protected function initSqlQuery(): bool
+    {
+        try {
+            $this->exportSchedule->loadMissing('owner');
+
+            $errors = ExportSchedule::validateSqlQuery($this->exportSchedule->sql_query ?? '');
+            if (! empty($errors)) {
+                Log::error('SQL query validation failed', [
+                    'schedule_id' => $this->exportSchedule->id,
+                    'errors' => $errors,
+                ]);
+
+                return false;
+            }
+
+            // Count rows by wrapping in a subquery
+            $countSql = "SELECT COUNT(*) as total FROM ({$this->exportSchedule->sql_query}) as subquery";
+            $totalRows = DB::select($countSql)[0]->total ?? 0;
+
+            $export = new Export;
+            $export->exporter = 'sql_query';
+            $export->total_rows = $totalRows;
+            $export->file_disk = config('export-scheduler.file_disk');
+            $export->file_name = $this->generateFileName();
+            $export->user()->associate($this->exportSchedule->owner);
+            $export->save();
+            $this->export = $export;
+
+            return true;
+        } catch (\Exception $exception) {
+            Log::error($exception->getMessage());
+
+            return false;
+        }
+    }
+
+    public function buildSqlQueryJobChain(): bool
+    {
+        try {
+            $this->export->unsetRelation('user');
+
+            Bus::chain([
+                Bus::batch([
+                    new ExportSqlQuery(
+                        export: $this->export,
+                        sql: $this->exportSchedule->sql_query,
+                    ),
+                ])->allowFailures(),
+
+                new ScheduledExportCompletion(
+                    export: $this->export,
+                    exportSchedule: $this->exportSchedule,
+                ),
+            ])->dispatch();
+
+            return true;
+        } catch (\Exception $exception) {
+            Log::error($exception->getMessage());
+
+            return false;
+        }
     }
 
     public function buildJobChain(): bool

--- a/src/Services/ScheduledExporter.php
+++ b/src/Services/ScheduledExporter.php
@@ -291,7 +291,16 @@ class ScheduledExporter
     public function buildSqlQueryJobChain(): bool
     {
         try {
+            $formats = $this->exportSchedule->formats;
+            $hasXlsx = in_array(ExportFormat::Xlsx, $formats);
+
             $this->export->unsetRelation('user');
+
+            $makeCreateXlsxFileJob = fn(): CreateXlsxFile => app(CreateXlsxFile::class, [
+                'export' => $this->export,
+                'columnMap' => [],
+                'options' => [],
+            ]);
 
             Bus::chain([
                 Bus::batch([
@@ -300,6 +309,9 @@ class ScheduledExporter
                         sql: $this->exportSchedule->sql_query,
                     ),
                 ])->allowFailures(),
+
+                // Conditional: CreateXlsxFile if XLSX format is requested
+                ...($hasXlsx ? [$makeCreateXlsxFileJob()] : []),
 
                 new ScheduledExportCompletion(
                     export: $this->export,

--- a/tests/Feature/SqlQueryScheduledReportTest.php
+++ b/tests/Feature/SqlQueryScheduledReportTest.php
@@ -70,10 +70,16 @@ it('rejects DROP statements embedded in select', function () {
     expect(collect($errors)->contains(fn ($e) => str_contains($e, 'DROP')))->toBeTrue();
 });
 
-it('rejects queries with multiple statements', function () {
+it('rejects queries with semicolons', function () {
     $errors = ExportSchedule::validateSqlQuery('SELECT 1; SELECT 2;');
     expect($errors)->not->toBeEmpty();
-    expect(collect($errors)->contains(fn ($e) => str_contains($e, 'Multiple statements')))->toBeTrue();
+    expect(collect($errors)->contains(fn ($e) => str_contains($e, 'Semicolons')))->toBeTrue();
+});
+
+it('rejects a single trailing semicolon', function () {
+    $errors = ExportSchedule::validateSqlQuery('SELECT id FROM users;');
+    expect($errors)->not->toBeEmpty();
+    expect(collect($errors)->contains(fn ($e) => str_contains($e, 'Semicolons')))->toBeTrue();
 });
 
 it('rejects TRUNCATE in query', function () {

--- a/tests/Feature/SqlQueryScheduledReportTest.php
+++ b/tests/Feature/SqlQueryScheduledReportTest.php
@@ -1,0 +1,151 @@
+<?php
+
+use Visualbuilder\ExportScheduler\Enums\ReportType;
+use Visualbuilder\ExportScheduler\Enums\ScheduleFrequency;
+use Visualbuilder\ExportScheduler\Filament\Exporters\UserExporter;
+use Visualbuilder\ExportScheduler\Models\ExportSchedule;
+use Visualbuilder\ExportScheduler\Services\ScheduledExporter;
+use Visualbuilder\ExportScheduler\Tests\Models\User;
+
+it('can create a sql query report schedule', function () {
+    $schedule = ExportSchedule::create([
+        'name' => 'SQL Test Report',
+        'report_type' => ReportType::SQL_QUERY,
+        'sql_query' => 'SELECT id, email FROM users',
+        'schedule_frequency' => ScheduleFrequency::DAILY,
+        'schedule_time' => '08:00',
+        'schedule_timezone' => 'UTC',
+        'formats' => ['csv'],
+        'owner_id' => auth()->id(),
+        'owner_type' => get_class(auth()->user()),
+        'enabled' => true,
+    ]);
+
+    expect($schedule->report_type)->toBe(ReportType::SQL_QUERY);
+    expect($schedule->sql_query)->toBe('SELECT id, email FROM users');
+    expect($schedule->isSqlQuery())->toBeTrue();
+});
+
+it('defaults report type to exporter for existing records', function () {
+    $schedule = ExportSchedule::create([
+        'name' => 'Standard Report',
+        'exporter' => UserExporter::class,
+        'schedule_frequency' => ScheduleFrequency::DAILY,
+        'schedule_time' => '08:00',
+        'columns' => [['name' => 'id', 'label' => 'ID']],
+        'owner_id' => auth()->id(),
+        'owner_type' => get_class(auth()->user()),
+    ]);
+
+    expect($schedule->report_type)->toBe(ReportType::EXPORTER);
+    expect($schedule->isSqlQuery())->toBeFalse();
+});
+
+it('validates SELECT-only queries', function () {
+    $errors = ExportSchedule::validateSqlQuery('SELECT id, email FROM users');
+    expect($errors)->toBeEmpty();
+});
+
+it('rejects INSERT statements', function () {
+    $errors = ExportSchedule::validateSqlQuery("INSERT INTO users (name) VALUES ('test')");
+    expect($errors)->not->toBeEmpty();
+    expect($errors[0])->toContain('must begin with SELECT');
+});
+
+it('rejects UPDATE statements', function () {
+    $errors = ExportSchedule::validateSqlQuery("UPDATE users SET name = 'test'");
+    expect($errors)->not->toBeEmpty();
+    expect($errors[0])->toContain('must begin with SELECT');
+});
+
+it('rejects DELETE statements', function () {
+    $errors = ExportSchedule::validateSqlQuery('DELETE FROM users');
+    expect($errors)->not->toBeEmpty();
+    expect($errors[0])->toContain('must begin with SELECT');
+});
+
+it('rejects DROP statements embedded in select', function () {
+    $errors = ExportSchedule::validateSqlQuery('SELECT 1; DROP TABLE users');
+    expect($errors)->not->toBeEmpty();
+    expect(collect($errors)->contains(fn ($e) => str_contains($e, 'DROP')))->toBeTrue();
+});
+
+it('rejects queries with multiple statements', function () {
+    $errors = ExportSchedule::validateSqlQuery('SELECT 1; SELECT 2;');
+    expect($errors)->not->toBeEmpty();
+    expect(collect($errors)->contains(fn ($e) => str_contains($e, 'Multiple statements')))->toBeTrue();
+});
+
+it('rejects TRUNCATE in query', function () {
+    $errors = ExportSchedule::validateSqlQuery('SELECT 1; TRUNCATE TABLE users');
+    expect($errors)->not->toBeEmpty();
+});
+
+it('allows complex SELECT queries with subqueries', function () {
+    $sql = 'SELECT u.id, u.email, (SELECT COUNT(*) FROM exports WHERE exports.user_id = u.id) as export_count FROM users u WHERE u.created_at > "2024-01-01"';
+    $errors = ExportSchedule::validateSqlQuery($sql);
+    expect($errors)->toBeEmpty();
+});
+
+it('allows SELECT with JOIN', function () {
+    $sql = 'SELECT users.id, users.email, organisations.name FROM users LEFT JOIN organisations ON users.id = organisations.primary_contact_id';
+    $errors = ExportSchedule::validateSqlQuery($sql);
+    expect($errors)->toBeEmpty();
+});
+
+it('allows SELECT with GROUP BY and HAVING', function () {
+    $sql = 'SELECT owner_type, COUNT(*) as total FROM documents GROUP BY owner_type HAVING total > 5';
+    $errors = ExportSchedule::validateSqlQuery($sql);
+    expect($errors)->toBeEmpty();
+});
+
+it('rejects INTO OUTFILE', function () {
+    $errors = ExportSchedule::validateSqlQuery("SELECT * FROM users INTO OUTFILE '/tmp/data.csv'");
+    expect($errors)->not->toBeEmpty();
+});
+
+it('can run sql query export', function () {
+    // The setUp already creates 1 user (admin@domain.com)
+    // Create additional users for the SQL query to return
+    User::create(['name' => 'User A', 'email' => 'a@test.com', 'password' => 'password']);
+    User::create(['name' => 'User B', 'email' => 'b@test.com', 'password' => 'password']);
+
+    $schedule = ExportSchedule::create([
+        'name' => 'SQL User Report',
+        'report_type' => ReportType::SQL_QUERY,
+        'sql_query' => 'SELECT id, name, email FROM users',
+        'schedule_frequency' => ScheduleFrequency::DAILY,
+        'schedule_time' => '08:00',
+        'schedule_timezone' => 'UTC',
+        'formats' => ['csv'],
+        'owner_id' => auth()->id(),
+        'owner_type' => get_class(auth()->user()),
+        'enabled' => true,
+    ]);
+
+    $exporter = new ScheduledExporter($schedule);
+    $result = $exporter->run();
+
+    expect($result)->toBeTrue();
+    expect($exporter->getTotalRows())->toBe(3); // admin + 2 created
+});
+
+it('rejects sql query export when validation fails', function () {
+    $schedule = ExportSchedule::create([
+        'name' => 'Bad SQL Report',
+        'report_type' => ReportType::SQL_QUERY,
+        'sql_query' => "DELETE FROM users",
+        'schedule_frequency' => ScheduleFrequency::DAILY,
+        'schedule_time' => '08:00',
+        'schedule_timezone' => 'UTC',
+        'formats' => ['csv'],
+        'owner_id' => auth()->id(),
+        'owner_type' => get_class(auth()->user()),
+        'enabled' => true,
+    ]);
+
+    $exporter = new ScheduledExporter($schedule);
+    $result = $exporter->run();
+
+    expect($result)->toBeFalse();
+});

--- a/tests/database/schema/test-schema.sql
+++ b/tests/database/schema/test-schema.sql
@@ -10,7 +10,9 @@ DROP TABLE IF EXISTS `export_schedules`;
 CREATE TABLE `export_schedules` (
   `id` int unsigned NOT NULL AUTO_INCREMENT,
   `name` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `exporter` varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `report_type` varchar(20) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'exporter',
+  `sql_query` text COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `exporter` varchar(191) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `columns` json DEFAULT NULL,
   `schedule_frequency` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
   `schedule_time` time NOT NULL DEFAULT '00:00:00',
@@ -231,3 +233,4 @@ INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (4,'2024_11_22_2027
 INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (5,'2024_11_22_213725_create_imports_table',1);
 INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (6,'2024_11_22_213726_create_exports_table',1);
 INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (7,'2024_11_22_213727_create_failed_import_rows_table',1);
+INSERT INTO `migrations` (`id`, `migration`, `batch`) VALUES (8,'2024_01_01_000002_add_sql_query_columns_to_export_schedules_table',1);


### PR DESCRIPTION
Add a second report creation mode allowing developers to paste raw SQL SELECT queries instead of choosing a Filament exporter. Includes SQL validation (SELECT-only, dangerous keyword blocking, multi-statement prevention), a dedicated ExportSqlQuery job, and 15 new tests.