### PR TITLE
feat(NB-523): register SQL query migration in service provider

### DIFF
--- a/src/ExportSchedulerServiceProvider.php
+++ b/src/ExportSchedulerServiceProvider.php
@@ -76,6 +76,7 @@ class ExportSchedulerServiceProvider extends PackageServiceProvider
         return [
             'create_export_scheduler_table',
             'add_dynamic_owner_columns_to_export_schedules_table',
+            'add_sql_query_columns_to_export_schedules_table',
         ];
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -14,7 +14,6 @@ use Filament\Tables\TablesServiceProvider;
 use Filament\Widgets\WidgetsServiceProvider;
 use Livewire\LivewireServiceProvider;
 use Orchestra\Testbench\TestCase as Orchestra;
-use RyanChandler\BladeCaptureDirective\BladeCaptureDirectiveServiceProvider;
 use Visualbuilder\ExportScheduler\ExportSchedulerServiceProvider;
 use Visualbuilder\ExportScheduler\Tests\Models\User;
 use Visualbuilder\ExportScheduler\Tests\Traits\CustomRefreshDatabase;
@@ -41,7 +40,6 @@ class TestCase extends Orchestra
     {
         return [
             ActionsServiceProvider::class,
-            BladeCaptureDirectiveServiceProvider::class,
             BladeHeroiconsServiceProvider::class,
             BladeIconsServiceProvider::class,
             FilamentServiceProvider::class,


### PR DESCRIPTION
CRITICAL FIX: The migration adding report_type and sql_query columns was never being published because it wasn't registered in the ExportSchedulerServiceProvider::getMigrations() method.

This was the root cause of the feature not working on dev.

Changes:
- Added 'add_sql_query_columns_to_export_schedules_table' to migrations array
- Removed missing BladeCaptureDirectiveServiceProvider from test setup

All implementation files were already in place from previous work:
- Migration for report_type and sql_query columns
- ReportType enum with EXPORTER and SQL_QUERY cases
- Model updates with validation and security checks
- Form fields with permission-based visibility
- ScheduledExporter service handling SQL query execution
- ExportSqlQuery job for CSV generation
- Comprehensive test coverage

Security:
- SQL validation (SELECT-only, blocks dangerous keywords)
- Role-based access control (Developer role required)
- Semicolon blocking to prevent query chaining
- Safe execution via Laravel DB::select()